### PR TITLE
Small fixes

### DIFF
--- a/broo
+++ b/broo
@@ -38,7 +38,7 @@ start_mumble_server() {
         nohup pw-jack mumble-server -ini ~/.config/broo/murmur.ini &>/dev/null 2>&1 &
     else
         nohup pw-jack murmurd -ini ~/.config/broo/murmur.ini &>/dev/null 2>&1 &
-    fi
+    fi &> /dev/null
 
     echo $! > "$VAR_RUN/murmur.pid"
 

--- a/broo
+++ b/broo
@@ -35,9 +35,9 @@ start_mumble_server() {
     # The PID is saved automatically due to the config in ini file.
 
     if [[ ! -z $(which mumble-server) ]]; then
-        nohup mumble-server -ini ~/.config/broo/murmur.ini &>/dev/null 2>&1 &
+        nohup pw-jack mumble-server -ini ~/.config/broo/murmur.ini &>/dev/null 2>&1 &
     else
-        nohup murmurd -ini ~/.config/broo/murmur.ini &>/dev/null 2>&1 &
+        nohup pw-jack murmurd -ini ~/.config/broo/murmur.ini &>/dev/null 2>&1 &
     fi
 
     echo $! > "$VAR_RUN/murmur.pid"
@@ -59,8 +59,7 @@ start_mumble_client () {
     # Starts the Mumble client, stores its PID, and waits till connection.
 
     # Start the client with logs for monitoring, and save PID.
-    nohup mumble "mumble://127.0.0.1" -platform offscreen \
-        &>"$VAR_RUN/nohup.out" &
+    nohup mumble "mumble://127.0.0.1" &>"$VAR_RUN/nohup.out" &
     echo $! > "$VAR_RUN/mumble_client.pid"
 
     # Wait till the user connects (presses OK).

--- a/setup_broo
+++ b/setup_broo
@@ -262,9 +262,9 @@ set_up_mumble() {
 
     # Start the server.
     if [[ ! -z $(which mumble-server) ]]; then
-        nohup mumble-server -ini ~/.config/broo/murmur.ini &>/dev/null 2>&1 &
+        nohup pw-jack mumble-server -ini ~/.config/broo/murmur.ini &>/dev/null 2>&1 &
     else
-        nohup murmurd -ini ~/.config/broo/murmur.ini &>/dev/null 2>&1 &
+        nohup pw-jack murmurd -ini ~/.config/broo/murmur.ini &>/dev/null 2>&1 &
     fi
 
     murmur_pid=$!

--- a/setup_broo
+++ b/setup_broo
@@ -265,7 +265,7 @@ set_up_mumble() {
         nohup pw-jack mumble-server -ini ~/.config/broo/murmur.ini &>/dev/null 2>&1 &
     else
         nohup pw-jack murmurd -ini ~/.config/broo/murmur.ini &>/dev/null 2>&1 &
-    fi
+    fi &> /dev/null
 
     murmur_pid=$!
     sleep 3  # Give time for it to set up.


### PR DESCRIPTION
First of, thank you for the script. After these changes it works well and has helped me a lot.

I had a problem with jack under pipewire. Adding `pw-jack` in front of the mumble-server calls fixed these problems. *NOTE* that this might break the script for people not using pipewire, but as I use pipewire exclusively I could not test that. Maybe another test is necessary in the appropriate parts of the script to only include this prefix when on pipewire.

Also I could not find any documentation on the mumble argument `-platform offscreen` which also caused trouble as mumble would not start (not even in the background). Removing the