### PR TITLE
Workaround for Mumble v1.5 hang in case "mumble_has_quit_normally" is set to false after quitting Broo

### DIFF
--- a/broo
+++ b/broo
@@ -72,7 +72,8 @@ start_mumble_client () {
     # can cause mumble to not connect to server, so we test during setup.
     # A file "no_offscreen" is created if we don't want to do offscreen.
     if [[ -f "$BROO_CFG_LOC/no_offscreen" ]]; then
-        nohup mumble "mumble://127.0.0.1" \ &>"$VAR_RUN/mumble_client.out" &
+        nohup mumble "mumble://127.0.0.1" \
+            &>"$VAR_RUN/mumble_client.out" &
     else
         nohup mumble "mumble://broo@127.0.0.1" -platform offscreen \
             &>"$VAR_RUN/mumble_client.out" &

--- a/broo
+++ b/broo
@@ -109,11 +109,17 @@ start_mumble_client () {
     # Save the PID.
     echo $! > "$VAR_RUN/mumble_client.pid"
 
-    # Wait till we establish a conenction. Upon connection, a line is logged
-    # starting with "ServerHandler: TLS cipher", so we monitor the logs.
+    # Wait till we establish a conenction. Upon connection, the server logs a
+    # line containing "Authenticated", so we monitor its logs. Give up after a
+    # while, so a client which never connects doesn't hang us forever.
     # tail + grep idea by 00prometheus on <https://superuser.com/a/900134>.
-    (tail -f "$VAR_RUN/mumble_client.out" &) | grep --line-buffered -q \
-                                                    "ServerHandler: TLS cipher"
+    if ! (tail -f "$VAR_RUN/murmur.out" &) \
+         | timeout 30 grep --line-buffered -q "Authenticated"; then
+        echo "Timed out waiting for the Mumble client to connect."
+        echo "Its logs are in $VAR_RUN/mumble_client.out. Use 'q' to clean up,"
+        echo "and 'p' if the server's certificate needs accepting."
+        exit 1
+    fi
 }  # End of start_mumble_client()
 
 

--- a/broo
+++ b/broo
@@ -54,6 +54,31 @@ start_mumble_server() {
 }  # End of start_mumble_server()
 
 
+reset_mumble_quit_flag() {
+    # Mark Mumble's settings as quit normally to avoid its recovery prompt.
+    show_warning="${1:-false}"
+
+    local mumble_cfg="$XDG_CONFIG_HOME/Mumble/Mumble/mumble_settings.json"
+    if [[ ! -f "$mumble_cfg" ]]; then
+        return
+    fi
+
+    local quit_key='"mumble_has_quit_normally":'
+    if ! grep -Eq "$quit_flag_false" "$mumble_cfg"; then
+        return
+    fi
+
+    local quit_flag_false="$quit_key[[:space:]]*false"
+    sed -i "s/$quit_flag_false/$quit_key true/" "$mumble_cfg"
+
+    if [[ "$show_warning" == "true" ]]; then
+        echo "Warning: Mumble had not quit properly from the previous run."
+        echo "If any issue persists, please try to inspect by starting the"
+        echo -e "GUI manually or by using 'broo -p'.\n"
+    fi
+}  # End of reset_mumble_quit_flag()
+
+
 stop_mumble_server() {
     # Stops the Mumble server, and deletes the PID file if it remains.
 
@@ -67,6 +92,8 @@ stop_mumble_server() {
 start_mumble_client () {
     # Starts the Mumble client (with logs for monitoring), stores its PID,
     # and waits till the connection to server is established.
+
+    reset_mumble_quit_flag "true"
 
     # We prefer offscreen, but there can be a rare case that using offscreen
     # can cause mumble to not connect to server, so we test during setup.
@@ -95,6 +122,7 @@ stop_mumble_client() {
 
     echo -n "."
     kill $(<"$VAR_RUN/mumble_client.pid")
+    reset_mumble_quit_flag
     rm "$VAR_RUN/mumble_client.pid"
     rm "$VAR_RUN/mumble_client.out"
 }  # End of stop_mumble_client()


### PR DESCRIPTION
We stop the Mumble client by killing it, so it never reaches the normal shutdown path which marks "mumble_has_quit_normally" in its settings.

Mumble 1.5 checks that flag on startup, and if a settings backup exists, it asks whether to load the backup instead of the possibly crash-causing settings. That prompt is a modal dialog, which is invisible (and hence unanswerable) when running with -platform offscreen, so the client stalls there and never connects. The wait for the connection then blocks forever, and Broo hangs after printing "Initialising Broo...".

Since the flag is left unset on every run, the first start after setting Mumble up works, and every start after that hangs.

Fix it by marking the settings as having quit normally ourselves before starting the client. Mumble before 1.5 has neither the settings file nor the prompt, so this is a no-op there.

While at it, watch the server's log for "Authenticated" instead of the client's log for "ServerHandler: TLS cipher". The latter is logged when the handler is set up, before we know whether connecting worked, so it isn't a signal that we are actually connected. The former has been logged by the server since at least 1.3, so this works across versions.

Also give up waiting after a while, so that a client which never connects tells us what happened instead of hanging indefinitely with no output.

Lastly, drop a stray escaped space in the no_offscreen branch, which was passing a literal space to mumble as an argument.